### PR TITLE
Adding formatting to fix the custom-heira lacking a preformat box

### DIFF
--- a/docs/satellite-configuration-tuning.rst
+++ b/docs/satellite-configuration-tuning.rst
@@ -231,14 +231,14 @@ MongoDb Tuning
 
 Under certain circumstances, mongod consumes randomly high memory (up to 1/2 of all RAM) and this aggressive memory usage limits other processes or can cause OOM killer to kill mongod. In order to overcome this situation, tune the cache size by referring the following steps:
 
-Update custom-hiera.yaml:
+**1.** Update custom-hiera.yaml:
 
--  Edit /etc/foreman-installer/custom-hiera.yaml and add the entry below inserting the value that is 20% of the physical RAM while keeping in mind the `guidlines <https://access.redhat.com/documentation/en-us/red_hat_satellite/6.7/html/installing_satellite_server_from_a_connected_network/preparing-environment-for-satellite-installation#satellite-storage-requirements_satellite>`_ in this case, approximately 6GB for a 32GB server::
+Edit /etc/foreman-installer/custom-hiera.yaml and add the entry below inserting the value that is 20% of the physical RAM while keeping in mind the `guidlines <https://access.redhat.com/documentation/en-us/red_hat_satellite/6.7/html/installing_satellite_server_from_a_connected_network/preparing_your_environment_for_installation#hardware_storage_prerequisites>`_ in this case, approximately 6GB for a 32GB server. Please note the formatting of the second line and the indent::
 
   mongodb::server::config_data:
    storage.wiredTiger.engineConfig.cacheSizeGB: 6
 
-- Run installer to apply changes::
+**2.** Run installer to apply changes::
 
   # satellite-installer
 


### PR DESCRIPTION
This fixes the formatting on the  mongodb::server::config_data showing up all on one line which will not work, this puts it into a formatted box:

``` 
  mongodb::server::config_data:
    storage.wiredTiger.engineConfig.cacheSizeGB: 6
```

something with latex would not allow this inside a bullet list so switched to a manual numbered list of steps.